### PR TITLE
Set link to point to the English AMO website

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Installation
 
-* Firefox: https://addons.mozilla.org/fr/firefox/addon/carbonalyser/
+* Firefox: https://addons.mozilla.org/en/firefox/addon/carbonalyser/
 * Chrome and Edge: [see this issue](https://github.com/carbonalyser/Carbonalyser/issues/42)
 
 ## Overview


### PR DESCRIPTION
The link in README.md is currently pointing to the French AMO website. It would be more consistent if it pointed to the English version instead (the README.md and the link in the repository description are in English).